### PR TITLE
feat: add relay chain auto-dependency for all parachains

### DIFF
--- a/app/src/features/assethub-migration/MigrationAlert.tsx
+++ b/app/src/features/assethub-migration/MigrationAlert.tsx
@@ -64,8 +64,9 @@ function Item({
               </p>
             ) : (
               <p className='text-small flex-1 text-left leading-normal font-bold text-white'>
-                The Assethub Migration starts on {sourceNetwork?.name} on July 7. After the migration, all
-                multisig/proxy on {sourceNetwork?.name} will be moved to {destNetwork?.name}.
+                The Assethub Migration starts on {sourceNetwork?.name} on{' '}
+                {sourceChain === 'kusama' ? 'October 7' : 'July 7'}. After the migration, all multisig/proxy on{' '}
+                {sourceNetwork?.name} will be moved to {destNetwork?.name}.
                 <a target='_blank' href={MIGRATION_NOTICE_DOCS_URL} className='text-white underline'>
                   View Details
                 </a>

--- a/app/src/hooks/useProxyBestBlock.ts
+++ b/app/src/hooks/useProxyBestBlock.ts
@@ -1,0 +1,48 @@
+// Copyright 2023-2024 dev.mimir authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useApi } from '@mimir-wallet/polkadot-core';
+
+import { useBestBlock } from './useBestBlock';
+import { useRelayBestBlock } from './useRelayBestBlock';
+
+/**
+ * Hook to get the appropriate best block for proxy announcement time calculations
+ *
+ * Some parachains (like assethub-kusama, assethub-paseo, assethub-westend) require using
+ * the relay chain block number instead of the parachain block number for calculating
+ * when proxy announcements become executable.
+ *
+ * @returns A tuple containing:
+ *   - bestBlock: The block header to use for time calculations
+ *   - isFetched: Whether the initial fetch has completed
+ *   - isFetching: Whether a fetch is currently in progress
+ *
+ * @remarks
+ * Selection logic:
+ * - If chain.useRelayBlockForProxy is true AND relay block is available:
+ *   Returns relay chain block
+ * - Otherwise:
+ *   Returns current parachain/chain block
+ *
+ * Fallback behavior:
+ * - If relay block is required but not yet available, falls back to parachain block
+ * - This ensures the UI remains functional even if relay chain API is slow to initialize
+ */
+export function useProxyBestBlock() {
+  const { chain } = useApi();
+  const parachainBlock = useBestBlock();
+  const relayBlock = useRelayBestBlock();
+
+  // Use relay chain block if:
+  // 1. Chain configuration requires it (useRelayBlockForProxy=true)
+  // 2. Relay block data is available
+  if (chain.useRelayBlockForProxy && relayBlock[0]) {
+    return relayBlock;
+  }
+
+  // Fallback to parachain block:
+  // - For chains that don't need relay block
+  // - When relay block is required but not yet available (graceful degradation)
+  return parachainBlock;
+}

--- a/app/src/hooks/useRelayBestBlock.ts
+++ b/app/src/hooks/useRelayBestBlock.ts
@@ -1,0 +1,66 @@
+// Copyright 2023-2024 dev.mimir authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useApi } from '@mimir-wallet/polkadot-core';
+import { useQuery } from '@mimir-wallet/service';
+
+import { useBlockInterval } from './useBlockInterval';
+
+/**
+ * Hook to fetch the best block from the relay chain of the current parachain
+ *
+ * This hook is specifically designed for parachains that require relay chain block numbers
+ * for proxy announcement time calculations (e.g., assethub-kusama, assethub-paseo, assethub-westend).
+ *
+ * @returns A tuple containing:
+ *   - bestBlock: The latest relay chain block header, or undefined if unavailable
+ *   - isFetched: Whether the initial fetch has completed
+ *   - isFetching: Whether a fetch is currently in progress
+ *
+ * @remarks
+ * - Returns undefined if the current chain is not a parachain (no relayChain config)
+ * - Returns undefined if the relay chain API is not initialized or ready
+ * - Automatically refetches at the chain's block interval
+ * - Query is disabled if relay chain API is not available
+ */
+export function useRelayBestBlock() {
+  const { chain, allApis } = useApi();
+
+  const relayChainKey = chain.relayChain;
+  const relayApi = relayChainKey ? allApis[relayChainKey] : undefined;
+  const relayGenesisHash = relayApi?.genesisHash;
+
+  const blockInterval = useBlockInterval();
+
+  const {
+    data: bestBlock,
+    isFetched,
+    isFetching
+  } = useQuery({
+    queryKey: ['relayBestBlock', relayChainKey] as const,
+    queryHash: `${relayGenesisHash}.api.rpc.chain.getHeader()`,
+    // Only enable query when:
+    // 1. Current chain has a relay chain (is a parachain)
+    // 2. Relay chain API is initialized and ready
+    enabled: !!relayApi?.isApiReady && !!relayChainKey,
+    refetchOnMount: false,
+    refetchInterval: blockInterval.toNumber(),
+    queryFn: async () => {
+      // Double-check API availability (defense in depth)
+      if (!relayApi?.api) {
+        throw new Error(`Relay chain API not available for ${relayChainKey || 'unknown chain'}`);
+      }
+
+      try {
+        const header = await relayApi.api.rpc.chain.getHeader();
+
+        return header;
+      } catch (error) {
+        console.error(`Failed to fetch relay chain block header for ${relayChainKey}:`, error);
+        throw error;
+      }
+    }
+  });
+
+  return [bestBlock, isFetched, isFetching] as const;
+}

--- a/app/src/transactions/hooks/useAnnouncementProgress.ts
+++ b/app/src/transactions/hooks/useAnnouncementProgress.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type AccountData, type ProxyTransaction, TransactionStatus, TransactionType } from '@/hooks/types';
-import { useBestBlock } from '@/hooks/useBestBlock';
+import { useProxyBestBlock } from '@/hooks/useProxyBestBlock';
 import { BN, u8aEq } from '@polkadot/util';
 import { useMemo } from 'react';
 
@@ -22,7 +22,7 @@ export function useAnnouncementProgress(
     [account.delegatees, transaction.delegate]
   );
 
-  const [bestBlock] = useBestBlock();
+  const [bestBlock] = useProxyBestBlock();
 
   const { data: result } = useQuery({
     queryKey: [transaction.delegate] as const,

--- a/app/src/transactions/hooks/useAnnouncementStatus.ts
+++ b/app/src/transactions/hooks/useAnnouncementStatus.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type AccountData, type Transaction, TransactionStatus, TransactionType } from '@/hooks/types';
-import { useBestBlock } from '@/hooks/useBestBlock';
+import { useProxyBestBlock } from '@/hooks/useProxyBestBlock';
 import { BN, u8aEq } from '@polkadot/util';
 import { useMemo } from 'react';
 
@@ -32,7 +32,7 @@ export function useAnnouncementStatus(
     [account.delegatees, transaction.delegate]
   );
 
-  const [bestBlock, isFetched, isFetching] = useBestBlock();
+  const [bestBlock, isFetched, isFetching] = useProxyBestBlock();
   const {
     data: result,
     isFetched: isFetchedResult,

--- a/packages/polkadot-core/src/config.ts
+++ b/packages/polkadot-core/src/config.ts
@@ -362,7 +362,8 @@ const kusamaEndpoints: Endpoint[] = [
     ss58Format: 2,
     explorerUrl: 'https://assethub-kusama.subscan.io/',
     statescanUrl: 'https://assethub-kusama.statescan.io/',
-    identityNetwork: 'people-kusama'
+    identityNetwork: 'people-kusama',
+    useRelayBlockForProxy: true
   },
   {
     key: 'people-kusama',
@@ -502,7 +503,8 @@ const paseoEndpoints: Endpoint[] = [
     httpUrl: 'https://asset-hub-paseo.dotters.network',
     genesisHash: '0xd6eec26135305a8ad257a20d003357284c8aa03d0bdb2b357ab0a22371e11ef2',
     explorerUrl: 'https://assethub-paseo.subscan.io/',
-    statescanUrl: 'https://assethub-paseo.statescan.io/'
+    statescanUrl: 'https://assethub-paseo.statescan.io/',
+    useRelayBlockForProxy: true
   },
   {
     key: 'passethub',
@@ -581,7 +583,8 @@ const westendEndpoints: Endpoint[] = [
     genesisHash: '0x67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9',
     explorerUrl: 'https://assethub-westend.subscan.io/',
     statescanUrl: 'https://assethub-westend.statescan.io/',
-    polkavm: true
+    polkavm: true,
+    useRelayBlockForProxy: true
   }
 ];
 

--- a/packages/polkadot-core/src/types.ts
+++ b/packages/polkadot-core/src/types.ts
@@ -27,6 +27,8 @@ export type Endpoint = {
   identityNetwork?: string;
   polkavm?: boolean;
   remoteProxyTo?: HexString;
+  // Indicates if proxy announcements use relay chain block numbers instead of parachain block numbers
+  useRelayBlockForProxy?: boolean;
 };
 
 export type Network = Endpoint & {

--- a/packages/polkadot-core/src/useNetworks.ts
+++ b/packages/polkadot-core/src/useNetworks.ts
@@ -44,24 +44,53 @@ function getEnabledNetworks(): [Network, ...Network[]] {
   ];
 }
 
+/**
+ * Enable a network in omni mode
+ *
+ * When enabling a network, this function automatically enables dependent networks:
+ * - Identity network: For chains that store identity data on a separate chain
+ * - Relay chain: For all parachains (chains with relayChain configured)
+ *
+ * @param key - The network key or genesis hash to enable
+ *
+ * @remarks
+ * - Only works in omni mode; does nothing in solo mode
+ * - Automatically enables identity network if configured
+ * - Automatically enables relay chain for all parachains
+ * - No-op if the network is already enabled
+ */
 export function enableNetwork(key: string) {
   useNetworks.setState((state) => {
+    // Only allow network management in omni mode
     if (state.mode !== 'omni') {
       return state;
     }
 
-    const identityNetwork = state.networks.find(
-      (item) => item.key === key || item.genesisHash === key
-    )?.identityNetwork;
+    const targetNetwork = state.networks.find((item) => item.key === key || item.genesisHash === key);
+    const identityNetwork = targetNetwork?.identityNetwork;
+    const relayChain = targetNetwork?.relayChain;
+
+    // If already enabled, no changes needed
+    if (state.networks.some((network) => network.enabled && network.key === key)) {
+      return { networks: state.networks };
+    }
 
     return {
-      networks: state.networks.some((network) => network.enabled && network.key === key)
-        ? state.networks
-        : (state.networks.map((item) => ({
-            ...item,
-            enabled:
-              key === item.key || key === item.genesisHash ? true : identityNetwork === item.key ? true : item.enabled
-          })) as [Network, ...Network[]])
+      networks: state.networks.map((item) => ({
+        ...item,
+        enabled:
+          // Enable the target network
+          key === item.key || key === item.genesisHash
+            ? true
+            : // Enable identity network if the target requires it
+              identityNetwork === item.key
+              ? true
+              : // Enable relay chain if the target is a parachain
+                relayChain === item.key
+                ? true
+                : // Keep existing enabled state for other networks
+                  item.enabled
+      })) as [Network, ...Network[]]
     };
   });
 }
@@ -76,22 +105,56 @@ export const useNetworks = create<{
   networks: getEnabledNetworks(),
   mode: getNetworkMode(),
   enableNetwork: enableNetwork,
+  /**
+   * Disable a network in omni mode
+   *
+   * This function prevents disabling networks that are required by other enabled networks:
+   * - Relay chains required by any enabled parachain cannot be disabled
+   * - At least one network must remain enabled at all times
+   *
+   * @param key - The network key to disable
+   *
+   * @remarks
+   * - Only works in omni mode; does nothing in solo mode
+   * - Cannot disable the last enabled network
+   * - Cannot disable relay chains required by any enabled parachains
+   * - No-op if the network is already disabled
+   */
   disableNetwork: (key: string) => {
     set((state) => {
+      // Only allow network management in omni mode
       if (state.mode !== 'omni') {
         return state;
       }
 
+      // Check if this relay chain is required by any enabled parachain
+      // All parachains need their relay chain for various operations
+      const isRequiredRelayChain = state.networks.some((network) => network.enabled && network.relayChain === key);
+
+      if (isRequiredRelayChain) {
+        // Cannot disable relay chain if required by any enabled parachains
+        console.warn(`Cannot disable relay chain ${key}: required by enabled parachains`);
+
+        return state;
+      }
+
+      // Must keep at least one network enabled
+      const enabledCount = state.networks.filter((item) => item.enabled).length;
+
+      if (enabledCount === 1) {
+        return state;
+      }
+
+      // If already disabled, no changes needed
+      if (state.networks.some((network) => !network.enabled && network.key === key)) {
+        return state;
+      }
+
       return {
-        networks:
-          state.networks.filter((item) => item.enabled).length === 1
-            ? state.networks
-            : state.networks.some((network) => !network.enabled && network.key === key)
-              ? state.networks
-              : (state.networks.map((item) => ({ ...item, enabled: key === item.key ? false : item.enabled })) as [
-                  Network,
-                  ...Network[]
-                ])
+        networks: state.networks.map((item) => ({
+          ...item,
+          enabled: key === item.key ? false : item.enabled
+        })) as [Network, ...Network[]]
       };
     });
   },


### PR DESCRIPTION
- Add useRelayBlockForProxy flag to config for assethub chains
- Implement useRelayBestBlock hook to fetch relay chain blocks
- Implement useProxyBestBlock hook to select correct block source
- Auto-enable relay chain when enabling any parachain in omni mode
- Auto-initialize relay chain API for parachains in solo mode
- Prevent disabling relay chains required by enabled parachains
- Update announcement hooks to use relay chain blocks when needed